### PR TITLE
Fix configuration directory and downloads directory

### DIFF
--- a/src/LidaTube.py
+++ b/src/LidaTube.py
@@ -44,8 +44,8 @@ class DataHandler:
         self.percent_completion = 0
 
         self.clients_connected_counter = 0
-        self.config_folder = "config"
-        self.download_folder = "downloads"
+        self.config_folder = "./config"
+        self.download_folder = "./downloads"
 
         if not os.path.exists(self.config_folder):
             os.makedirs(self.config_folder)


### PR DESCRIPTION
With the current LidaTube image, it doesn't matter if you add a cookies.txt file on the path /lidatube/config, it will never be read because `self.config_folder = "config"` won't refer to the current directory where LidaTube has been run... Adding `./` before config and downloads ensures python looks for them in the right place. I modified this because I wasn't able to use my cookies.txt file in any way, debugged and noticed that `if os.path.exists(full_cookies_path) else None` was always false. So I made this small change and now it works and my cookies.txt file is being read again

I have pushed an image to docker.io/dpkgifoodeb/lidatube:latest if you want to try it
