### PR TITLE
feat: adding support for Opus, Vorbis, and AAC/M4A codecs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Certain values can be set via environment variables:
 * __sync_schedule__: Schedule times to run (comma seperated values in 24hr). Defaults to ``
 * __minimum_match_ratio__: Minimum percentage for a match. Defaults to `90`
 * __secondary_search__: Method for secondary search (YTS or YTDLP). Defaults to `YTS`.
-* __preferred_codec__: Preferred codec (mp3). Defaults to `mp3`.
+* __preferred_codec__: Preferred audio codec. Supports any yt-dlp compatible codec including: mp3, flac, vorbis, opus, m4a/aac. Defaults to `mp3`.
 * __attempt_lidarr_import__: Attempt to import each song directly into Lidarr. Defaults to `False`.
 
 

--- a/test_codec_clean.sh
+++ b/test_codec_clean.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Clean codec testing script
+CODEC=$1
+PORT=$2
+LIDARR_API_KEY=$3
+LIDARR_HOST=$4
+
+if [ -z "$CODEC" ] || [ -z "$PORT" ] || [ -z "$LIDARR_API_KEY" ] || [ -z "$LIDARR_HOST" ]; then
+    echo "Usage: ./test_codec_clean.sh <codec> <port> <lidarr_api_key> <lidarr_host>"
+    echo "Example: ./test_codec_clean.sh opus 5645 1234567890 192.168.1.25"
+    exit 1
+fi
+
+echo "Remember to build the container before running this script!"
+
+echo "🧹 Cleaning up previous test..."
+docker stop lidatube-test 2>/dev/null
+docker rm lidatube-test 2>/dev/null
+docker volume rm lidatube-${CODEC}-test-config 2>/dev/null
+docker volume rm lidatube-${CODEC}-test-downloads 2>/dev/null
+
+echo "📦 Creating fresh volumes..."
+docker volume create lidatube-${CODEC}-test-config
+docker volume create lidatube-${CODEC}-test-downloads
+
+echo "🚀 Starting clean container for ${CODEC} on port ${PORT}..."
+docker run -d \
+  --name lidatube-test \
+  -p ${PORT}:5000 \
+  -v lidatube-${CODEC}-test-config:/lidatube/config:rw \
+  -v lidatube-${CODEC}-test-downloads:/lidatube/downloads:rw \
+  -e preferred_codec=${CODEC} \
+  -e lidarr_address=http://${LIDARR_HOST}:8686 \
+  -e lidarr_api_key=${LIDARR_API_KEY} \
+  lidatube-test
+
+echo "✅ Lidatube ready! Access at http://localhost:${PORT}"
+echo "🔍 To check every file in the downloads folder: docker exec lidatube-test find /lidatube/downloads -type f"
+echo "🔍 To check for specific files with the extension ${CODEC}: docker exec lidatube-test find /lidatube/downloads -name "*.${CODEC}" | wc -l"
+echo "🛑 To stop the test container either run: docker stop lidatube-test && docker rm lidatube-test"
+echo "or start a new run with the same command, it will automatically stop the old one"
+echo ""
+echo "📋 Do you want to check the logs? (y/n)"
+read -n 1 -s check_logs
+echo ""
+if [ "$check_logs" = "y" ]; then
+    docker logs -f lidatube-test
+fi


### PR DESCRIPTION
hello!

first of all, i want to express my sincere appreciation for your work on this project, it has been truly revolutionary for my library.

this pull request introduces support for a wider range of audio codecs. while FLAC is excellent for quality, i recognized the need for more storage-efficient options other than the standard mp3. to address this, I have implemented support for Opus, Vorbis, and AAC/M4A.

here is a summary of the changes:

1. lidatube can now handle mp3, flac, opus, vorbis, and aac/m4a codecs

2. i have refactored sections of the metadata handling to ensure compatibility and consistency across all new formats. i would particularly appreciate your review of this section.

3. i have tested each codec, both new and old, by downloading and playing back tracks. in my testing, all files were downloaded correctly and played without issues.

4. full thumbnail support is working for all codecs. i had to paid special attention to Opus and Vorbis, which both presented challenges with embedded thumbnails, but, for my testing, i can confirm they display thumbnails correctly using VLC

5. i added a bash script to help test each codec and clean the dev env automatically, hope you find that useful!

i am very excited about the possibility of contributing to this project. if you are open to external contributions, i would be happy to help further :)

PS: this is my first ever contribution to an opensource project, i hope to have done things right!